### PR TITLE
Sync speaking and animation

### DIFF
--- a/3d_avatar_chatbot/frontend/src/App.jsx
+++ b/3d_avatar_chatbot/frontend/src/App.jsx
@@ -31,6 +31,7 @@ function App() {
     start,
     status,
     newAudioStartTime,
+    processing,
   } = useConversation();
 
   if (!isChrome && !isSafari) {
@@ -62,6 +63,7 @@ function App() {
             messages={messages}
             removeFirstMessage={removeFirstMessage}
             newAudioStartTime={newAudioStartTime}
+            isProcessingAudio={processing}
           />
         </Canvas>
       </div>

--- a/3d_avatar_chatbot/frontend/src/components/Avatar/Avatar.jsx
+++ b/3d_avatar_chatbot/frontend/src/components/Avatar/Avatar.jsx
@@ -30,6 +30,7 @@ export function Avatar(props) {
     removeFirstMessage,
     isLoading,
     newAudioStartTime,
+    isProcessingAudio,
     ...rest
   } = props;
 
@@ -41,6 +42,7 @@ export function Avatar(props) {
     messages,
     removeFirstMessage,
     speaking,
+    isProcessingAudio,
     setAnimation,
     setFacialExpression,
     setLipSync,

--- a/3d_avatar_chatbot/frontend/src/components/Avatar/useProcessMessages.js
+++ b/3d_avatar_chatbot/frontend/src/components/Avatar/useProcessMessages.js
@@ -18,9 +18,11 @@ export function useProcessMessages({
   setLipSync,
   removeFirstMessage,
   messages,
+  isProcessingAudio,
 }) {
   useEffect(() => {
     if (!Array.isArray(messages) || messages.length === 0) return;
+    if (!isProcessingAudio) return;
 
     const message = messages[0];
     if (typeof message !== "object" || message === null) return;
@@ -45,6 +47,7 @@ export function useProcessMessages({
     setFacialExpression,
     setLipSync,
     removeFirstMessage,
+    isProcessingAudio,
   ]);
 
   useEffect(() => {

--- a/3d_avatar_chatbot/frontend/src/hooks/connection.ts
+++ b/3d_avatar_chatbot/frontend/src/hooks/connection.ts
@@ -311,5 +311,6 @@ export const useConversation = () => {
     sendMessage, // Function to send a new message
     ref, // Reference to the input element
     newAudioStartTime,
+    processing,
   };
 };


### PR DESCRIPTION
# Summary

Currently, the animation and speech are not synchronized. When a message is received, `useProcessMessages` begins processing it, causing the animation to start immediately, but there's a slight delay before the lips (because it depends on `newAudioStartTime`) and audio begin.

To address this issue in this PR, we now wait for the audio processing to start first. Once the audio processing begins, we then start processing the messages, which triggers the lip-syncing and the animations.


# Tests

I tested it locally, and everything appears to be in sync. However, I encountered a separate issue where the microphone cannot be used to chat with the 3D Bot. I'm not sure why this is happening, but it seems to be unrelated to the fix.